### PR TITLE
Add colored recipients and support spaced fingerprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Using Vault is super easy. Below is the list of all the possible operations:
 `vault get` - Retrieves an encrypted file from your Vault and decrypts it.  
 `vault remove` - Removes specified recipients from the Vault. It will automatally keep te integrity of your Vault by upgrading encrypted recipients  
 `vault import` - Imports all the current recipients in your vault. Alternatively you can specifiy a keyserver to import from  
+`vault recipients` - Lists vault recipients and it's current status in the user keyring (missing / untrusted / trusted) i.e:  
+
+![recipients](https://cloud.githubusercontent.com/assets/1578458/10444397/5e543a6a-713c-11e5-98da-99dfd38e3b88.png)
 
 
 #This sounds cool, where do I get it?

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Using Vault is super easy. Below is the list of all the possible operations:
 
 `vault init` - Creates a new Vault in the directory you're located  
 `vault add` - Adds one or more recipients to your Vault. Vault will automatically re-encrypt all your files for the new recipient  
-`vault set` - Stores something (text or file) into your Vault and ecrypts it for all of your vault recipients  
+`vault set` - Stores something (text or file) into your Vault and encrypts it for all of your vault recipients  
 `vault get` - Retrieves an encrypted file from your Vault and decrypts it.  
 `vault remove` - Removes specified recipients from the Vault. It will automatally keep te integrity of your Vault by upgrading encrypted recipients  
 `vault import` - Imports all the current recipients in your vault. Alternatively you can specifiy a keyserver to import from  

--- a/commands/recipients/recipients.go
+++ b/commands/recipients/recipients.go
@@ -1,6 +1,8 @@
 package recipients
 
 import (
+	"github.com/fatih/color"
+	"github.com/franela/vault/gpg"
 	"github.com/franela/vault/ui"
 	"github.com/franela/vault/vault"
 	"github.com/mitchellh/cli"
@@ -11,6 +13,10 @@ Usage
 
     Lists current vault recipients.
 `
+
+var missingRecipients = []string{}
+var trustedRecipients = []string{}
+var untrustedRecipients = []string{}
 
 func Factory() (cli.Command, error) {
 	return recipientsCommand{}, nil
@@ -28,13 +34,54 @@ func (recipientsCommand) Run(args []string) int {
 		ui.Printf("Error opening Vaultfile: %s", err)
 		return 1
 	} else {
-		for _, recipient := range vaultFile.Recipients {
-			ui.Printf("%s\n", recipient.ToString())
+		if gpgFingerprints, err := getGPGFingerprints(); err != nil {
+			return 1
+		} else {
+			for _, recipient := range vaultFile.Recipients {
+				if isTrusty, exists := gpgFingerprints[recipient.Fingerprint]; exists {
+					if isTrusty {
+						trustedRecipients = append(trustedRecipients, recipient.ToString())
+					} else {
+						untrustedRecipients = append(untrustedRecipients, recipient.ToString())
+					}
+
+				} else {
+					missingRecipients = append(missingRecipients, recipient.ToString())
+				}
+			}
+
 		}
-		return 0
 	}
+	if len(trustedRecipients) > 0 {
+		ui.Printf("Trusted recipients:\n")
+		for _, recipient := range trustedRecipients {
+			ui.Printf("    %s\n", color.GreenString(recipient))
+		}
+	}
+
+	if len(untrustedRecipients) > 0 {
+		ui.Printf("Untrusted recipients:\n")
+		ui.Printf("  (use gpg --sign-key <fingerprint> to sign recipient key):\n")
+		for _, recipient := range untrustedRecipients {
+			ui.Printf("    %s\n", color.CyanString(recipient))
+		}
+	}
+
+	if len(missingRecipients) > 0 {
+		ui.Printf("Missing recipients:\n")
+		ui.Printf("  (use vault import to add missing recipients):\n")
+		for _, recipient := range missingRecipients {
+			ui.Printf("    %s\n", color.RedString(recipient))
+		}
+	}
+	return 0
+
 }
 
 func (recipientsCommand) Synopsis() string {
 	return "Lists all your current vault recipients."
+}
+
+func getGPGFingerprints() (map[string]bool, error) {
+	return gpg.GetKeysWithFingerprints()
 }

--- a/commands/recipients/recipients_test.go
+++ b/commands/recipients/recipients_test.go
@@ -1,12 +1,13 @@
 package recipients
 
 import (
+	"strings"
+	"testing"
+
 	. "github.com/franela/goblin"
 	"github.com/franela/vault/ui"
 	"github.com/franela/vault/vault"
 	"github.com/franela/vault/vault/testutils"
-	"strings"
-	"testing"
 )
 
 func TestRecipients(t *testing.T) {

--- a/vault/vaultfile.go
+++ b/vault/vaultfile.go
@@ -22,6 +22,7 @@ func NewRecipient(recipient string) (*VaultRecipient, error) {
 	}
 
 	recipientFingerprint := strings.Split(recipient, ":")[0]
+	recipientFingerprint = strings.Replace(recipientFingerprint, " ", "", -1)
 
 	if hexFingerprint, err := hex.DecodeString(recipientFingerprint); err != nil {
 		return nil, fmt.Errorf("\nSupplied fingerprint \"%s\" does not have the correct format\n", recipientFingerprint)

--- a/vault/vaultfile_test.go
+++ b/vault/vaultfile_test.go
@@ -48,6 +48,11 @@ func TestVaultfile(t *testing.T) {
 			g.Assert(recipient).Equal(&VaultRecipient{Fingerprint: "3B9CEC3B5069113E2ED39AC9843E01FBCE44AAAA", Name: "a@a.com"})
 		})
 
+		g.It("Should show allow spaced fingerprints", func() {
+			recipient, _ := NewRecipient("3B9C EC3B 5069 113E 2ED3 9AC9 843E 01FB CE44 AAAA:a@a.com")
+			g.Assert(recipient).Equal(&VaultRecipient{Fingerprint: "3B9CEC3B5069113E2ED39AC9843E01FBCE44AAAA", Name: "a@a.com"})
+		})
+
 		g.It("Should require both parameters to be present", func() {
 			_, err := NewRecipient("a@a.com")
 			g.Assert(err != nil).IsTrue()
@@ -65,7 +70,7 @@ func TestVaultfile(t *testing.T) {
 		})
 
 		g.It("Should validate that first has the correct amount of characters", func() {
-			_, err := NewRecipient("a@a.com:3B9CEC3B50691")
+			_, err := NewRecipient("3B9CEC3B50691:a@a.com")
 			g.Assert(err != nil).IsTrue()
 		})
 


### PR DESCRIPTION
The following PR shows a colored output when listing vault recipients
using `vault recipients` command.

It also allows to add vault recipients using spaced fingerprints as
follows `vault add ABCD EF123 ...`

Here's an example for the colored output:
![image](https://cloud.githubusercontent.com/assets/1578458/10444397/5e543a6a-713c-11e5-98da-99dfd38e3b88.png)
