### PR TITLE
Support stdin input when adding values to Vault

### DIFF
--- a/commands/set/set.go
+++ b/commands/set/set.go
@@ -17,7 +17,7 @@ const setHelpText = `
 Usage: vault set [options] vaultpath [text]
 
    Sets something into the vault. Either plain text or files using the -f 
-   parameter are allowed.
+   parameter are allowed. You can also read from stdin using "-".
 
 Options: 
     
@@ -37,23 +37,10 @@ func (setCommand) Help() string {
 }
 
 func (setCommand) Run(args []string) int {
-
-	vaultFile, err := vault.LoadVaultfile()
-
-	if err != nil {
-		ui.Printf("%s", err)
-		return 1
-	}
-
-	if len(vaultFile.Recipients) == 0 {
-		ui.Printf("Cannot set in vault if Vaultfile has no recipients. Use `vault add` to add one or more recipients.\n")
-		return 3
-	}
-
-	cmdFlags := flag.NewFlagSet("set", flag.ContinueOnError)
-
 	var fileName string
 
+	// parse flags
+	cmdFlags := flag.NewFlagSet("set", flag.ContinueOnError)
 	cmdFlags.StringVar(&fileName, "f", "", "specify the file to encrypt")
 
 	if err := cmdFlags.Parse(args); err != nil {
@@ -63,57 +50,68 @@ func (setCommand) Run(args []string) int {
 
 	args = cmdFlags.Args()
 
+	// make sure no excess arguments were given
 	if len(args) > 2 {
 		ui.Printf(setHelpText)
 		return 1
-	} else if len(args) == 0 && fileName != "" {
+	}
+
+	// check that at least a file, or plain text input was given
+	if len(args) != 2 && fileName == "" {
+		ui.Printf(setHelpText)
+		return 1
+	}
+
+	// in case a file was given, add the fileName to the arguments to populate the key
+	if len(args) == 0 {
 		args = append(args, path.Base(fileName))
 	}
 
+	// load the Vaultfile
+	vaultFile, err := vault.LoadVaultfile()
+
+	if err != nil {
+		ui.Printf("%s", err)
+		return 1
+	}
+
+	// make sure the current Vaultfile has recipients
+	if len(vaultFile.Recipients) == 0 {
+		ui.Printf("Cannot set in vault if Vaultfile has no recipients. Use `vault add` to add one or more recipients.\n")
+		return 3
+	}
+
+	// make sure the path to encrypt is under the current path
+	vaultPath := args[0]
+	if ok, err := isUnderCurrentPath(vaultPath); err != nil || !ok {
+		if err != nil {
+			ui.Printf("%s\n", err)
+		} else {
+			ui.Printf("Destination should be under current path.\n")
+		}
+		return 1
+	}
+
+	// make sure the vault path has the ".asc" extension
+	if filepath.Ext(vaultPath) != ".asc" {
+		vaultPath = vaultPath + ".asc"
+	}
+
 	if len(fileName) > 0 {
-		vaultPath := args[0]
-		if ok, err := isUnderCurrentPath(vaultPath); err != nil || !ok {
-			if err != nil {
-				ui.Printf("%s\n", err)
-			} else {
-				ui.Printf("Destination should be under current path.\n")
-			}
-			return 1
-		}
-		if filepath.Ext(vaultPath) != ".asc" {
-			vaultPath = vaultPath + ".asc"
-		}
-		err := gpg.EncryptFile(path.Join(vault.GetHomeDir(), vaultPath), fileName, vaultFile.Recipients)
-		if err != nil {
-			ui.Printf("%s", err)
-			return 1
-		}
+		// encrypt a file
+		err = gpg.EncryptFile(path.Join(vault.GetHomeDir(), vaultPath), fileName, vaultFile.Recipients)
+	} else if args[1] == "-" {
+		// encrypt from stdin
+		ui.Printf("Enter the text below, end with EOF (Ctrl + D):\n")
+		err = gpg.EncryptFile(path.Join(vault.GetHomeDir(), vaultPath), "-", vaultFile.Recipients)
 	} else {
-		if len(args) != 2 {
-			ui.Printf(setHelpText)
-			return 1
-		}
+		// encrypt plain text
+		err = gpg.Encrypt(path.Join(vault.GetHomeDir(), vaultPath), args[1], vaultFile.Recipients)
+	}
 
-		text := args[1]
-		vaultPath := args[0]
-		if ok, err := isUnderCurrentPath(vaultPath); err != nil || !ok {
-			if err != nil {
-				ui.Printf("%s\n", err)
-			} else {
-				ui.Printf("Destination should be under current path.\n")
-			}
-			return 1
-		}
-		if filepath.Ext(vaultPath) != ".asc" {
-			vaultPath = vaultPath + ".asc"
-		}
-
-		err := gpg.Encrypt(path.Join(vault.GetHomeDir(), vaultPath), text, vaultFile.Recipients)
-
-		if err != nil {
-			ui.Printf("%s", err)
-			return 1
-		}
+	if err != nil {
+		ui.Printf("%s", err)
+		return 1
 	}
 
 	return 0

--- a/commands/set/set_test.go
+++ b/commands/set/set_test.go
@@ -108,6 +108,27 @@ func TestSet(t *testing.T) {
 				g.Assert(out).Equal("This is a test")
 			})
 
+			g.It("Should encrypt from stdin, if \"-\" is given as the second argument", func() {
+				testutils.SetTestGPGHome("bob")
+
+				v := &vault.Vaultfile{}
+				v.Recipients = []vault.VaultRecipient{
+					vault.VaultRecipient{Fingerprint: "2B13EC3B5769013E2ED29AC9643E01FBCE44E394", Name: "bob@example.com"},
+				}
+				v.Save()
+
+				c, _ := Factory()
+
+				f, err := os.Open(path.Join(testutils.GetProjectDir(), "testdata", "set_test"))
+				g.Assert(err).Equal(nil)
+				os.Stdin = f
+				c.Run([]string{"set_test", "-"})
+
+				out, err := gpg.Decrypt(path.Join(vault.GetHomeDir(), "set_test.asc"))
+				g.Assert(err == nil).IsTrue()
+				g.Assert(out).Equal("This is a test")
+			})
+
 			g.It("Should fail if Vaultfile recipients is empty", func() {
 				c, _ := Factory()
 

--- a/gpg/gpg.go
+++ b/gpg/gpg.go
@@ -114,6 +114,9 @@ func EncryptFile(filePath string, sourceFile string, recipients []vault.VaultRec
 
 	cmd := exec.Command("gpg", encryptArgs...)
 	cmd.Env = nil
+
+	// connect Stdin to subcommand, so that the user can input data
+	cmd.Stdin = os.Stdin
 	cmd.Stderr = logger
 	_, err := cmdExec.Output(cmd)
 


### PR DESCRIPTION
This allows the following:

```
$ vault set something -
Enter the text below, end with EOF (Ctrl + D):
this is super secret
and super
multi
line

$ vault get something
this is super secret
and super
multi
line
```

This is both more secure, as the secrets are not saved to the history and allows for saving multi-line values to Vault without first creating a file.